### PR TITLE
qmi-ping: Improve finding test services and error handling. Add command-line option to define instance number

### DIFF
--- a/qmi_ping.c
+++ b/qmi_ping.c
@@ -80,6 +80,7 @@ int main(int argc, char **argv)
 	struct sockaddr_qrtr sq;
 	struct qrtr_packet pkt;
 	unsigned int msg_id;
+	int instance = -1;
 	unsigned long node;
 	unsigned long port = 0;
 	struct timeval tv = { INT_MAX, };
@@ -93,10 +94,13 @@ int main(int argc, char **argv)
 	int ret;
 	int fd;
 
-	while ((opt = getopt(argc, argv, "c:")) != -1) {
+	while ((opt = getopt(argc, argv, "c:i:")) != -1) {
 		switch (opt) {
 		case 'c':
 			count = strtoul(optarg, NULL, 10);
+			break;
+		case 'i':
+			instance = strtoul(optarg, NULL, 10);
 			break;
 		default:
 			usage();
@@ -169,7 +173,8 @@ int main(int argc, char **argv)
 					break;
 			}
 
-			if (pkt.node == node) {
+			if (pkt.node == node &&
+					(instance == -1 || instance == pkt.instance)) {
 				port = pkt.port;
 
 				tv.tv_sec = 0;

--- a/qmi_ping.c
+++ b/qmi_ping.c
@@ -162,8 +162,12 @@ int main(int argc, char **argv)
 
 		switch (pkt.type) {
 		case QRTR_TYPE_NEW_SERVER:
-			if (!pkt.node && !pkt.port)
-				break;
+			if (!pkt.node && !pkt.port) {
+				if (!port)
+					err(1, "unable to find matching test service");
+				else
+					break;
+			}
 
 			if (pkt.node == node) {
 				port = pkt.port;

--- a/qmi_ping.c
+++ b/qmi_ping.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
 
 	fcntl(fd, F_SETFL, O_NONBLOCK);
 
-	ret = qrtr_new_lookup(fd, 15, 1, 0);
+	ret = qrtr_new_lookup(fd, 15, 0, 0);
 	if (ret < 0)
 		err(1, "failed to register new lookup");
 


### PR DESCRIPTION
The test service on some nodes such as adsp node (5) can have instance number other than 0.