### PR TITLE
Makefile: allow $(CFLAGS), $(LDFLAGS) override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 OUT := qmi-ping
 
-CFLAGS := -Wall -g -O2
-LDFLAGS := -lqrtr
+CFLAGS += -Wall -g -O2
+LDFLAGS += -lqrtr
+prefix = /usr/local
 
 SRCS := qmi_ping.c qmi_test.c
 


### PR DESCRIPTION
The caller might have specified `CFLAGS` or `LDFLAGS`. Let's respect those.
Additionally add `prefix` var declaration defaulting to `/usr/local`.

See https://github.com/andersson/rmtfs/commit/5eb67a1fb5a5238f3d560b38505b891285eb3c45 for something similar already done on `rmtfs` previously.